### PR TITLE
Improve opening lines of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpO₂
 
-SpO₂ is a monitor for Kubernetes pods. For more detail and background, see the [blog post announcing the release of the project](https://blog.meilisearch.com/spo2-the-little-dynamic-monitoring-tool/). 
+SpO₂ is a monitor for any program using the HTTP protocol. For more detail and background, see the [blog post announcing the release of the project](https://blog.meilisearch.com/spo2-the-little-dynamic-monitoring-tool/). 
 
 (In medicine, SpO₂ refers to oxygen saturation levels in blood and is used as a measure of a person's health. O₂ is the scientific designation for an oxygen atom.) 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SpO₂
-SpO₂ is oxygen saturation and is used in medical person monitoring.
+
+SpO₂ is a monitor for Kubernetes pods. For more detail and background, see the [blog post announcing the release of the project](https://blog.meilisearch.com/spo2-the-little-dynamic-monitoring-tool/). 
+
+(In medicine, SpO₂ refers to oxygen saturation levels in blood and is used as a measure of a person's health. O₂ is the scientific designation for an oxygen atom.) 
 
 This project uses [sled](https://github.com/spacejam/sled) to permanently save the health checked URLs.
 It provides a websocket API that returns the changing status of the health checked URLs.


### PR DESCRIPTION
I have proposed here a change in the opening lines of the Readme to clarify the tool's purpose first (and link to more details), while maintaining the explanation of the medical connection for its name.

These opening lines are not only what a person would see first, but they are used as the brief description shown for the project in a github search or in a person's list of repos, like Clement's. Having the etymology of the project name first was doing a disservice to anyone who might casually come across it in such places, or even if they came to the project. :-) 

Hope you feel this is a helpful improvement. Feel free, of course, to refine the wording however you like, if indeed you would accept the PR. 